### PR TITLE
Increase sleep time to avoid a race condition when a test completes

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -363,7 +363,8 @@ public class LocalWorker implements Worker, ConsumerCallback {
         totalMessagesReceived.reset();
 
         try {
-            Thread.sleep(100);
+            // TODO: Must wait for all tasks in executor to complete. For now, sleep a while.
+            Thread.sleep(5000);
 
             producers.parallelStream().forEach((BenchmarkProducer benchmarkProducer) -> {
                 try {


### PR DESCRIPTION
This is a temporary bug fix for issue #19. The bug in the issue occurs with 48 segments which causes the workload shutdown process to take longer than expected. There was a 100 ms sleep to wait for the executor thread to shutdown. This has been increased to 5000 ms to accommodate this workload.
In the future, the stopAll method needs to wait for all executor tasks to complete.