### PR TITLE
Fixing issue 18: PravegaConfig.enableTransaction has the default value of true

### DIFF
--- a/driver-pravega/src/main/java/io/openmessaging/benchmark/driver/pravega/config/PravegaConfig.java
+++ b/driver-pravega/src/main/java/io/openmessaging/benchmark/driver/pravega/config/PravegaConfig.java
@@ -27,7 +27,7 @@ public class PravegaConfig {
 
     // includeTimestampInEvent must be true to measure end-to-end latency.
     public boolean includeTimestampInEvent = true;
-    public boolean enableTransaction = true;
+    public boolean enableTransaction = false;
     // defines how many events the benchmark writes on each transaction prior
     // committing it (only applies if transactional writers are enabled).
     public int eventsPerTransaction = 1;


### PR DESCRIPTION
Fixing https://github.com/pravega/openmessaging-benchmark/issues/18 "Open-messaging benchmark artefact from package/target build for driver-pravega has mutliple reconnections and produces 0.0 Mb/sec speed in summary output. "