### PR TITLE
Issue 23: Add option to disable deleting of streams

### DIFF
--- a/driver-pravega/src/main/java/io/openmessaging/benchmark/driver/pravega/PravegaBenchmarkDriver.java
+++ b/driver-pravega/src/main/java/io/openmessaging/benchmark/driver/pravega/PravegaBenchmarkDriver.java
@@ -139,7 +139,9 @@ public class PravegaBenchmarkDriver implements BenchmarkDriver {
             for (String topic : createdTopics) {
                 log.info("deleteTopics: topic={}", topic);
                 streamManager.sealStream(scopeName, topic);
-                streamManager.deleteStream(scopeName, topic);
+                if (config.deleteStreams) {
+                    streamManager.deleteStream(scopeName, topic);
+                }
             }
         }
     }

--- a/driver-pravega/src/main/java/io/openmessaging/benchmark/driver/pravega/config/PravegaConfig.java
+++ b/driver-pravega/src/main/java/io/openmessaging/benchmark/driver/pravega/config/PravegaConfig.java
@@ -37,4 +37,8 @@ public class PravegaConfig {
     // Number of events/kbytes per second to trigger a Segment split in Pravega.
     public int eventsPerSecond = DEFAULT_STREAM_AUTOSCALING_VALUE;
     public int kbytesPerSecond = DEFAULT_STREAM_AUTOSCALING_VALUE;
+
+    // By default, streams created for benchmarking will be deleted at the end of the test.
+    // Set to false to keep the streams.
+    public boolean deleteStreams = true;
 }


### PR DESCRIPTION
The option "deleteStreams=false" can be set in pravega.yaml to disable deletion of streams at the end of the tests.