### PR TITLE
Issue 17: Use CompositeByteBuffer to add timestamp to payload

### DIFF
--- a/driver-pravega/pravega.yaml
+++ b/driver-pravega/pravega.yaml
@@ -29,6 +29,6 @@ client:
 writer:
   enableConnectionPooling: False
 
-includeTimestampInEvent: False
+includeTimestampInEvent: true
 enableStreamAutoScaling: False
 eventsPerSecond: 10000


### PR DESCRIPTION
This should avoid copying the payload buffer when adding a timestamp to the event.
Also changed the default behavior to include timestamps in events.