### PR TITLE
Upgrade GRPC version to be consistent across all transitive dependencies

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -182,7 +182,7 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-all</artifactId>
-			<version>1.31.0</version>
+			<version>1.24.2</version>
 		</dependency>
 
 		<!-- set Netty version to be consistent across all transitive dependencies  -->

--- a/driver-pravega/pom.xml
+++ b/driver-pravega/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-all</artifactId>
-            <version>1.31.0</version>
+            <version>1.24.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR fixes [Issue 41](https://github.com/pravega/openmessaging-benchmark/issues/41)