### PR TITLE
Issue#45 Setting pravega version when building omb with mvn property overriding

### DIFF
--- a/driver-pravega/pom.xml
+++ b/driver-pravega/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <!--Specify pravegaVersion in properties or use default: 0.7.1-->
-        <!--Provide Pravega version for build: mvn clean install  "-DpravegaVersion=0.8.0-2508.30406cf-SNAPSHOT" -DskipTests=true -->
+        <!--Provide Pravega version for build: mvn clean install  "-DpravegaVersion=0.8.0-2508.30406cf-SNAPSHOT" -DskipTests=true -Dlicense.skip=true-->
         <pravegaVersion>0.7.1</pravegaVersion>
     </properties>
 


### PR DESCRIPTION
Setting pravega version when building omb with mvn property overriding is useful for Jenkins pipe-lines:
```
mvn clean install  "-DpravegaVersion=0.8.0-2508.30406cf-SNAPSHOT" -DskipTests=true 
```

```
<properties>
        <!--Specify pravegaVersion in properties or use default: 0.7.1-->
        <!--Provide Pravega version for build: mvn clean install  "-DpravegaVersion=0.8.0-2508.30406cf-SNAPSHOT" -DskipTests=true -->
        <pravegaVersion>0.7.1</pravegaVersion>
    </properties>
...
 <dependency>
            <groupId>io.pravega</groupId>
            <artifactId>pravega-client</artifactId>
            <version>${pravegaVersion}</version>
        </dependency>
```