### PR TITLE
Issue 47: Set EFS provisioned throughput to 1000

### DIFF
--- a/driver-pravega/deploy/provision-pravega-aws.tf
+++ b/driver-pravega/deploy/provision-pravega-aws.tf
@@ -190,7 +190,7 @@ resource "aws_instance" "metrics" {
 # Change the EFS provisioned TP here
 resource "aws_efs_file_system" "tier2" {
   throughput_mode = "provisioned"
-  provisioned_throughput_in_mibps = 500
+  provisioned_throughput_in_mibps = 1000
   tags = {
     Name = "pravega-tier2"
   }


### PR DESCRIPTION
**Change log description**
Set EFS provisioned throughput to 1000, as it has been used in the last months of experimentation.

**Purpose of the issue**
Fixes #47.

**How to verify it**
Deployed with this change in the last round of experiments performed.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>