### PR TITLE
Issue 36: Prepare for release 0.1

### DIFF
--- a/driver-pravega/deploy/vars.yaml
+++ b/driver-pravega/deploy/vars.yaml
@@ -1,5 +1,5 @@
 ---
-pravegaVersion: "0.7.1"
+pravegaVersion: "0.8.0"
 zookeeperVersion: "3.5.5"
 bookkeeperVersion: "4.9.2"
 prometheusVersion: "2.2.1"

--- a/driver-pravega/pom.xml
+++ b/driver-pravega/pom.xml
@@ -30,9 +30,9 @@
     <artifactId>driver-pravega</artifactId>
 
     <properties>
-        <!--Specify pravegaVersion in properties or use default: 0.7.1-->
+        <!--Specify pravegaVersion in properties or use default: 0.8.0-->
         <!--Provide Pravega version for build: mvn clean install  "-DpravegaVersion=0.8.0-2508.30406cf-SNAPSHOT" -DskipTests=true -Dlicense.skip=true-->
-        <pravegaVersion>0.7.1</pravegaVersion>
+        <pravegaVersion>0.8.0</pravegaVersion>
     </properties>
 
     <repositories>
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>io.pravega</groupId>
             <artifactId>pravega-keycloak-client</artifactId>
-            <version>0.6.1</version>
+            <version>0.8.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Change log description**
Updated Pravega artifact versions to 0.8.0.

**Purpose of the change**
Fixes #36.

**What the code does**
Updates Pravega artifact versions to 0.8.0 for Pravega driver.

**How to verify it**
`mvn clean install -DskipTests -Dlicense.skip` should pass.

Deployed and it works on AWS:
```
7:50:04.991 [main] INFO io.openmessaging.benchmark.worker.DistributedWorkersEnsemble - Workers list - producers: [http://10.0.0.23:8080]
17:50:04.991 [main] INFO io.openmessaging.benchmark.worker.DistributedWorkersEnsemble - Workers list - consumers: [http://10.0.0.90:8080]
17:50:04.993 [main] INFO io.openmessaging.benchmark.Benchmark - --------------- WORKLOAD : 1 producer / 1 consumers on 1 topic --- DRIVER : Pravega---------------
17:50:11.047 [main] INFO io.openmessaging.benchmark.WorkloadGenerator - Created 1 topics in 504.30452 ms
17:50:11.800 [main] INFO io.openmessaging.benchmark.WorkloadGenerator - Created 1 consumers in 748.872367 ms
17:50:11.866 [main] INFO io.openmessaging.benchmark.WorkloadGenerator - Created 1 producers in 65.297628 ms
17:50:11.866 [main] INFO io.openmessaging.benchmark.WorkloadGenerator - Waiting for consumers to be ready
17:50:12.022 [main] INFO io.openmessaging.benchmark.WorkloadGenerator - All consumers are ready
17:50:12.023 [main] INFO io.openmessaging.benchmark.WorkloadGenerator - ----- Starting warm-up traffic ------
17:50:22.188 [main] INFO io.openmessaging.benchmark.WorkloadGenerator - Pub rate 54240.6 msg/s / 55.5 MB/s | Cons rate 54240.7 msg/s / 55.5 MB/s | Backlog: 0 msg | Pub Latency (ms) avg: 17.1 - 50%: 11.8 - 99%: 114.8 - 99.9%: 152.6 - Max: 168.8
```

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>