### PR TITLE
Substitute netty-tcnative-boringssl-static 2.0.17.Final with netty-common and netty-buffer 4.1.50.Final

### DIFF
--- a/driver-pravega/pom.xml
+++ b/driver-pravega/pom.xml
@@ -73,9 +73,15 @@
 
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>2.0.17.Final</version>
-        </dependency>
+            <artifactId>netty-common</artifactId>
+            <version>4.1.50.Final</version>
+         </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>4.1.50.Final</version>
+         </dependency>
 
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Update netty dependencies in pravega POM: `netty-common` and `netty-buffer`